### PR TITLE
Create further symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ install-lib: $(SOFILE)
 	install -D $^ $(DESTDIR)$(LIBDIR)/$^.$(VERSION)
 	install -D $(ILCLIENT) $(DESTDIR)$(LIBDIR)
 	ln -s -r $(DESTDIR)$(LIBDIR)/$^.$(VERSION) $(DESTDIR)$(LIBDIR)/$^
+	ln -s -r $(DESTDIR)$(LIBDIR)/$^.$(VERSION) $(DESTDIR)$(LIBDIR)/$^.$(MAJOR)
 	mkdir $(DESTDIR)$(INCDIR)
 	cp *.h $(DESTDIR)$(INCDIR)/
 	cp $(ILCDIR)/*.h $(DESTDIR)$(INCDIR)/


### PR DESCRIPTION
Looks like enigma2 links against librpihddevice.so with internal soname librpihddevice.so.1 and requires librpihddevice.so.1 at runtime / loadtime. So add another symlink.